### PR TITLE
ci: run pre-commit with uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           echo "Installed uv version is ${{ steps.setup-uv.outputs.uv-version }}"
           echo "Installed Python version is $(python --version)"
           uv python list
-      - uses: mschoettle/pre-commit-action@v4.0.1
+      - uses: mschoettle/pre-commit-action@v4.0.2
         env:
           SKIP: markdownlint-cli2
       - name: Run markdownlint


### PR DESCRIPTION
Run `pre-commit` using `uvx` which is already installed.
And, install Python using `uv` at the same time instead of using the one that is in `ubuntu-latest`.